### PR TITLE
remove broken attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,13 +52,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      - name: Attest
-        uses: actions/attest-build-provenance@v3
-        id: attest
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
 
   github:
     runs-on: ubuntu-latest
@@ -77,14 +70,9 @@ jobs:
         working-directory: ${{ github.workspace }}/snaggle
         run: |
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build .
-          sha256sum snaggle > snaggle.sha256
       - name: Create github release
         working-directory: ${{ github.workspace }}/snaggle
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create ${{ github.ref_name }} --generate-notes 'snaggle#Snaggle ${{ github.ref_name }}'  'snaggle.sha256#SHA256 Checksum'
-      - name: Attest
-        uses: actions/attest-build-provenance@v3
-        with:
-          subject-checksums: snaggle.sha256
+          gh release create ${{ github.ref_name }} --generate-notes 'snaggle#Snaggle ${{ github.ref_name }}'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 # Changelog snaggle
 
+## [v0.1.1] - fix release machinery
+
+### Fixes
+
+- removed attestations from automated release process
+
 ## [v0.1.0] - initial CLI (Go)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -48,13 +48,9 @@ Exit Codes:
   COPY --from=ghcr.io/MusicalNinjaDad/snaggle /snaggle /bin/
   ```
 
-Note: Attestation available with github CLI: `gh attestation verify oci://ghcr.io/musicalninjadad/snaggle:latest -R MusicalNinjaDad/snaggle`
-
 ### Download
 
 > Grab the latest release binary (& SHA) from GitHub [`MusicalNinjaDad/snaggle/releases`](https://github.com/MusicalNinjaDad/snaggle/releases)
-
-Note: Attestation available with github CLI: `gh attestation verify path/to/downloaded/snaggle -R MusicalNinjaDad/snaggle`
 
 ### Go install
 


### PR DESCRIPTION
## Summary by Sourcery

Remove broken attestations and related checksum handling from the release workflow and documentation.

Enhancements:
- Remove attestation and SHA256 checksum steps from the GitHub Actions release workflow
- Simplify the GitHub release creation command by omitting checksum artifact

CI:
- Eliminate ‘Attest’ steps and checksum generation in .github/workflows/release.yml

Documentation:
- Remove attestation instructions from README.md