### PR TITLE
fix capitalisation in docker installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Exit Codes:
 ### In a container (easiest)
 
   ```docker
-  COPY --from=ghcr.io/MusicalNinjaDad/snaggle /snaggle /bin/
+  COPY --from=ghcr.io/musicalninjadad/snaggle /snaggle /bin/
   ```
 
 ### Download


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Update Docker COPY instruction to reference ghcr.io/musicalninjadad/snaggle with lowercase registry path