### PR TITLE
fix automated releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
         with:
           push: true
           outputs:
-            type=local,dest=/.build
+            type=local,dest=./.build
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -111,4 +111,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create ${{ needs.version.outputs.semver }} --generate-notes '.build/snaggle#Snaggle ${{ needs.version.outputs.semver }}'
+          gh release create ${{ needs.version.outputs.semver }} --generate-notes ./.build/snaggle#Snaggle ${{ needs.version.outputs.semver }}'


### PR DESCRIPTION
## Summary by Sourcery

Fix the automated release workflow by ensuring the repository is checked out, storing build artifacts in a dedicated directory, and updating the release command to reference the new artifact path.

CI:
- Add actions/checkout@v5 step to the release workflow to enable workspace access
- Change docker build-push-action output destination from the repository root to '/.build' to isolate build artifacts
- Update the 'gh release create' command to use the release notes file from the '.build' directory