### PR TITLE
fix automated releasing when pushing a version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - id: tag_check
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |
-          main_sha=$(git show-ref --verify refs/heads/main | awk '{ print $1 }')
+          main_sha=$(git show-ref --verify refs/remotes/origin/main | awk '{ print $1 }')
           if [[ ${{ github.sha }} != $main_sha ]]; then
             echo "::error title=Not main::Automated releasing is only possible for the head commit on main"
             exit 1


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Use refs/remotes/origin/main instead of refs/heads/main for tag_check in release workflow