### PR TITLE
fix automated releasing when pushing a version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - id: tag_check
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |
-          main_sha=$(git show-ref --verify refs/remotes/origin/main | awk '{ print $1 }')
+          main_sha=$(git ls-remote origin refs/heads/main | awk '{ print $1 }')
           if [[ ${{ github.sha }} != $main_sha ]]; then
             echo "::error title=Not main::Automated releasing is only possible for the head commit on main"
             exit 1


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix release workflow by fetching the main branch SHA via git ls-remote for accurate version-tag validation.