### PR TITLE
fix automated releasing: docker output location

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,12 +103,15 @@ jobs:
         with:
           push: true
           outputs:
-            type=local,dest=./.build
+            type=local,dest=${{ github.workspace }}/.build
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: List workspace files
+        run: ls -Ral ${{ github.workspace }}
 
       - name: Create github release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create ${{ needs.version.outputs.semver }} --generate-notes ./.build/snaggle#Snaggle ${{ needs.version.outputs.semver }}'
+          gh release create ${{ needs.version.outputs.semver }} --generate-notes ${{ github.workspace }}/.build/snaggle#Snaggle ${{ needs.version.outputs.semver }}'


### PR DESCRIPTION
## Summary by Sourcery

Fix the release workflow to use the correct build artifact location and add debugging for workspace contents.

Bug Fixes:
- Use an absolute GitHub workspace path for the Docker build output destination
- Update the GitHub release creation command to reference the absolute build artifact path

Enhancements:
- Add a step to list all files in the GitHub workspace for debugging