### PR TITLE
fix automated releasing: typo in gh release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,4 +114,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create ${{ needs.version.outputs.semver }} --generate-notes ${{ github.workspace }}/.build/snaggle#Snaggle ${{ needs.version.outputs.semver }}
+          gh release create ${{ needs.version.outputs.semver }} --generate-notes '${{ github.workspace }}/.build/snaggle#Snaggle ${{ needs.version.outputs.semver }}'


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Remove trailing single quote from gh release create command in release.yml